### PR TITLE
Yazzy/open

### DIFF
--- a/chunked_buffer.c
+++ b/chunked_buffer.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <malloc.h>
 
+#include "common.h"
 #include "chunked_buffer.h"
 
 struct chunked_buffer {

--- a/common.h
+++ b/common.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#define EXECFUSE_MAX_FILESIZE 65536
+#define EXECFUSE_MAX_PATHLEN 4096

--- a/examples/xmp/create
+++ b/examples/xmp/create
@@ -1,4 +1,10 @@
 #!/bin/sh
 # Optional script: if not implemented, write_file will be called for any file
 # Arguments: path mode
+
+# If something echo'ed here, execfuse will try to open that file to create, and
+# further file operations on file descriptor will be performed against that open file.
+# Eg.
+# echo "$HOME/.cache/$1"
+
 exit 0

--- a/examples/xmp/open
+++ b/examples/xmp/open
@@ -1,4 +1,10 @@
 #!/bin/sh
 # Optional script: if not implemented, read_file will be called for any file
 # Arguments: path
+
+# If something echo'ed here, execfuse will try to open that file, and
+# further file operations on file descriptor will be performed against that open file.
+# Eg.
+# echo "$HOME/.cache/$1"
+
 exit 0

--- a/execfuse.c
+++ b/execfuse.c
@@ -295,7 +295,7 @@ static int write_the_file(struct myinfo* i, const char* path) {
     return 0;
 }
 
-static int execfuse_open_internal(const char *path, struct fuse_file_info *fi, int flags, mode_t mode)
+static int execfuse_open_internal(const char *path, struct fuse_file_info *fi, mode_t mode)
 {
 	int open_err;
 	struct chunked_buffer* backend_file_buf;
@@ -304,31 +304,9 @@ static int execfuse_open_internal(const char *path, struct fuse_file_info *fi, i
 	bool internal;
 	int fd;
 
-fprintf(stderr, "fi->flags = %u ", fi->flags);
-if(fi->flags&O_APPEND) fprintf(stderr, "%s ", "O_APPEND");
-if(fi->flags&O_ASYNC) fprintf(stderr, "%s ", "O_ASYNC");
-if(fi->flags&O_CREAT) fprintf(stderr, "%s ", "O_CREAT");
-if(fi->flags&O_DIRECT) fprintf(stderr, "%s ", "O_DIRECT");
-if(fi->flags&O_DIRECTORY) fprintf(stderr, "%s ", "O_DIRECTORY");
-if(fi->flags&O_EXCL) fprintf(stderr, "%s ", "O_EXCL");
-if(fi->flags&O_LARGEFILE) fprintf(stderr, "%s ", "O_LARGEFILE");
-if(fi->flags&O_NOATIME) fprintf(stderr, "%s ", "O_NOATIME");
-if(fi->flags&O_NOCTTY) fprintf(stderr, "%s ", "O_NOCTTY");
-if(fi->flags&O_NOFOLLOW) fprintf(stderr, "%s ", "O_NOFOLLOW");
-if(fi->flags&O_NONBLOCK) fprintf(stderr, "%s ", "O_NONBLOCK");
-if(fi->flags&O_NDELAY) fprintf(stderr, "%s ", "O_NDELAY");
-if(fi->flags&O_SYNC) fprintf(stderr, "%s ", "O_SYNC");
-if(fi->flags&O_TRUNC) fprintf(stderr, "%s ", "O_TRUNC");
-if(fi->flags&O_RDONLY) fprintf(stderr, "%s ", "O_RDONLY");
-if(fi->flags&O_WRONLY) fprintf(stderr, "%s ", "O_WRONLY");
-if(fi->flags&O_RDWR) fprintf(stderr, "%s ", "O_RDWR");
-if(fi->flags&O_SYNC) fprintf(stderr, "%s ", "O_SYNC");
-fprintf(stderr, "\n");
-
-
     STATIC_MODE_STRING(mode, modestr);
 	
-	if(flags & O_CREAT)
+	if(fi->flags & O_CREAT)
 	{
 		script_name = "create";
 	}
@@ -360,7 +338,7 @@ fprintf(stderr, "\n");
 	    {
 	    	internal = FALSE;
 	    	
-			fd = open(backend_file, flags, mode);
+			fd = open(backend_file, fi->flags, mode);
 			if(fd == -1)
 			{
 				return errno;
@@ -408,12 +386,13 @@ fprintf(stderr, "\n");
 
 static int execfuse_open(const char *path, struct fuse_file_info *fi)
 {
-	return execfuse_open_internal(path, fi, 0, -1);
+	return execfuse_open_internal(path, fi, -1);
 }
 
 static int execfuse_create(const char *path, mode_t mode, struct fuse_file_info *fi)
 {
-    int ret = execfuse_open_internal(path, fi, O_CREAT, mode);
+	fi->flags |= O_CREAT;
+    int ret = execfuse_open_internal(path, fi, mode);
     return ret;
 }
 

--- a/execfuse.c
+++ b/execfuse.c
@@ -173,6 +173,19 @@ struct myinfo {
     int failed;
 };
 
+void setenv_mountpoint(int argc, char** argv)
+{
+    char* mp_buf = malloc(4096);
+    if(mp_buf == NULL) abort();
+    struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
+    if(fuse_parse_cmdline(&args, &mp_buf, NULL, NULL)!=0) abort();
+    char* mountpoint;
+    if(asprintf(&mountpoint, "%s", mp_buf)==-1) abort();
+    free(mp_buf);
+    setenv("EXECFUSE_MOUNTPOINT", mountpoint, 1);
+    free(mountpoint);
+}
+
 
 static int call_script_ll(const char* script_name, 
                         const char*const* params, 
@@ -561,6 +574,7 @@ int main(int argc, char *argv[])
     if(ret && ret!=ENOSYS) return ret;
     
     
+    setenv_mountpoint(argc-1, argv+1);
     struct fuse_args args = FUSE_ARGS_INIT(argc-1, argv+1);
     fuse_opt_parse(&args, NULL, NULL, NULL);
     fuse_opt_add_arg(&args, "-odirect_io");

--- a/execfuse.c
+++ b/execfuse.c
@@ -14,12 +14,11 @@
 #include <sys/time.h>
 #include <semaphore.h>
 
+#include "common.h"
 #include "chunked_buffer.h"
 #include "execute_script.h"
 
 #define SCRIPT_API_VERSION "0"
-#define EXECFUSE_MAX_FILESIZE 65536
-#define EXECFUSE_MAX_PATHLEN 4096
 
 #define STATIC_MODE_STRING(bits, var) \
  char var[16];\
@@ -239,10 +238,6 @@ static int call_script_stdout_write(void* ii, const char* buf, int len) {
     return len;
 }
 
-static struct chunked_buffer* call_script_stdout(const char* script_name, const char* param) {
-	return call_script_stdout_ret(script_name, param, NULL, NULL);
-}
-
 static struct chunked_buffer* call_script_stdout_ret(const char* script_name, const char* param1, const char* param2, int* call_return_code) {
     const char* params[]={param1, param2, NULL};
     struct chuncked_buffer_with_cursor cbuf;
@@ -259,6 +254,10 @@ static struct chunked_buffer* call_script_stdout_ret(const char* script_name, co
         return NULL;
     }
     return cbuf.content;
+}
+
+static struct chunked_buffer* call_script_stdout(const char* script_name, const char* param) {
+	return call_script_stdout_ret(script_name, param, NULL, NULL);
 }
 
 static int read_the_file_write(void* ii, const char* buf, int len) {
@@ -552,7 +551,7 @@ static int execfuse_mknod(const char *path, mode_t mode, dev_t rdev)
 static int execfuse_mkdir(const char *path, mode_t mode)
 {
 	STATIC_MODE_STRING(mode, b);
-    return -call_script_simple("mkdir", path, b);
+    return -call_script_simple2("mkdir", path, b);
 }
 
 static int execfuse_unlink(const char *path)

--- a/execfuse.c
+++ b/execfuse.c
@@ -341,7 +341,7 @@ static int execfuse_open_internal(const char *path, struct fuse_file_info *fi, m
 			fd = open(backend_file, fi->flags, mode);
 			if(fd == -1)
 			{
-				return errno;
+				return -errno;
 			}
 		}
 	}
@@ -354,8 +354,8 @@ static int execfuse_open_internal(const char *path, struct fuse_file_info *fi, m
 	else
 	{
 		/* exec script indicated error while opening this file */
-		/* reflecting the error code */
-		return open_err;
+		/* reflecting the error code to fuse */
+		return -open_err;
 	}
 	
 	/* allocate file info object */

--- a/execute_script.c
+++ b/execute_script.c
@@ -20,6 +20,10 @@ int execute_script(
 						read_t stdin_fn, void* stdin_obj,
                         write_t stdout_fn, void* stdout_obj
 						) {
+fprintf(stderr, "execute_script(%s, %s, %s", directory, script_name, params[0]);
+int debug_n;
+for(debug_n=1; params[debug_n]; debug_n++) fprintf(stderr, ", %s", params[debug_n]);
+fprintf(stderr, ")\n");
     
 	int ppcount=0;
 	int i;

--- a/execute_script.c
+++ b/execute_script.c
@@ -32,7 +32,7 @@ int execute_script(
 	const char** argv = (const char**)malloc((ppcount+pcount+2)*sizeof(char*));
 	assert(argv!=NULL);
 	
-	char script_path[4096];
+	char script_path[EXECFUSE_MAX_PATHLEN];
 	
 	sprintf(script_path, "%s/%s", directory, script_name);
 
@@ -88,7 +88,7 @@ int execute_script(
     if(to_be_read!=-1    && maxfd<to_be_read   ) maxfd = to_be_read   ;
     ++maxfd;
     
-    char buf[65536];
+    char buf[EXECFUSE_MAX_FILESIZE];
     fd_set rfds;
     fd_set wfds;
     

--- a/execute_script.c
+++ b/execute_script.c
@@ -9,6 +9,7 @@
 #include <sys/wait.h>
 
 
+#include "common.h"
 #include "execute_script.h"
 
 int execute_script(

--- a/execute_script.c
+++ b/execute_script.c
@@ -20,10 +20,6 @@ int execute_script(
 						read_t stdin_fn, void* stdin_obj,
                         write_t stdout_fn, void* stdout_obj
 						) {
-fprintf(stderr, "execute_script(%s, %s, %s", directory, script_name, params[0]);
-int debug_n;
-for(debug_n=1; params[debug_n]; debug_n++) fprintf(stderr, ", %s", params[debug_n]);
-fprintf(stderr, ")\n");
     
 	int ppcount=0;
 	int i;


### PR DESCRIPTION
- source out constants
- source out often used code for converting `mode_t` to octal-represented string
- add kind-a-proxy feature: `open` script may output a physical file path which will be opened and file descriptor operations will be performed against this fd. operations supporting "backend file" feature:
  - fgetattr
  - read
  - write
  - release
  - ftruncate
- introduce `call_script_stdout_ret()` which not only saves the output but also preserves the return code of called script.